### PR TITLE
feat: add exit code descriptions map

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ Never main() {
 }
 ```
 
+You can also access the description of the exit codes:
+
+```dart
+import 'package:all_exit_codes/all_exit_codes.dart';
+
+void main() {
+  int code = wrongUsage;
+  print('Exit code $code: ${exitCodeDescriptions[code]}');
+}
+```
+
 ## LICENSE
 
 [BSD 3-Clause License](./LICENSE)

--- a/lib/all_exit_codes.dart
+++ b/lib/all_exit_codes.dart
@@ -4,3 +4,4 @@
 library;
 
 export 'src/all_exit_codes_consts.dart';
+export 'src/all_exit_codes_map.dart';

--- a/lib/src/all_exit_codes_map.dart
+++ b/lib/src/all_exit_codes_map.dart
@@ -1,0 +1,24 @@
+import 'all_exit_codes_consts.dart';
+
+/// A map of exit codes to their descriptions.
+const Map<int, String> exitCodeDescriptions = {
+  success: 'The operation was successful.',
+  generalError: 'An error that occurred during the operation.',
+  misuseOfShellBuiltins: 'The command line usage is incorrect.',
+  notADirectory: 'The specified path is not a directory.',
+  wrongUsage: 'The command line usage is incorrect.',
+  unableToOpenInputFile: 'The specified input file could not be opened.',
+  fileExists: 'The specified file already exists.',
+  unableToCreateTemporaryFile: 'A temporary file could not be created.',
+  unableToOpenOutputFile: 'The specified output file could not be opened.',
+  unableToOpenOutputFileForWriting: 'The specified output file could not be opened for writing.',
+  unableToOpenOutputFileForReading: 'The specified output file could not be opened for reading.',
+  ioError: 'An input/output error occurred.',
+  tryAgain: 'A temporary failure occurred, try again later.',
+  configurationError: 'A configuration error occurred.',
+  cantExecute: 'The command invoked cannot execute.',
+  notFound: 'The command was not found.',
+  invalidArgumentToExit: 'An invalid argument was passed to the exit command.',
+  userTerminated: 'The script was terminated by the user.',
+  unknown: 'An unknown exit status occurred.',
+};

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -10,5 +10,13 @@ void main() {
     test('Check some codes', () {
       expect(wrongUsage, 64);
     });
+
+    test('Check exitCodeDescriptions map', () {
+      expect(exitCodeDescriptions[success], 'The operation was successful.');
+      expect(exitCodeDescriptions[wrongUsage],
+          'The command line usage is incorrect.');
+      expect(exitCodeDescriptions[ioError], 'An input/output error occurred.');
+      expect(exitCodeDescriptions.length, 19);
+    });
   });
 }


### PR DESCRIPTION
This PR adds a map of exit code descriptions to the `all_exit_codes` package. This allows users to easily retrieve the description of an exit code.

Changes:
- Created `lib/src/all_exit_codes_map.dart` with `exitCodeDescriptions` map.
- Exported `src/all_exit_codes_map.dart` in `lib/all_exit_codes.dart`.
- Added tests for the new map in `test/all_exit_codes_test.dart`.
- Updated `README.md` to demonstrate how to use `exitCodeDescriptions`.

---
*PR created automatically by Jules for task [5601606196820980158](https://jules.google.com/task/5601606196820980158) started by @insign*