### PR TITLE
Add exit code descriptions map

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -54,3 +54,26 @@ const int userTerminated = 130;
 
 /// 255 - Unknown - An unknown exit status occurred.
 const int unknown = 255;
+
+/// Map of exit codes to their descriptions.
+const Map<int, String> exitCodeDescriptions = {
+  success: 'The operation was successful.',
+  generalError: 'An error that occurred during the operation.',
+  misuseOfShellBuiltins: 'The command line usage is incorrect.',
+  notADirectory: 'The specified path is not a directory.',
+  wrongUsage: 'The command line usage is incorrect.',
+  unableToOpenInputFile: 'The specified input file could not be opened.',
+  fileExists: 'The specified file already exists.',
+  unableToCreateTemporaryFile: 'A temporary file could not be created.',
+  unableToOpenOutputFile: 'The specified output file could not be opened.',
+  unableToOpenOutputFileForWriting: 'The specified output file could not be opened for writing.',
+  unableToOpenOutputFileForReading: 'The specified output file could not be opened for reading.',
+  ioError: 'An input/output error occurred.',
+  tryAgain: 'A temporary failure occurred, try again later.',
+  configurationError: 'A configuration error occurred.',
+  cantExecute: 'The command invoked cannot execute.',
+  notFound: 'The command was not found.',
+  invalidArgumentToExit: 'An invalid argument was passed to the exit command.',
+  userTerminated: 'The script was terminated by the user.',
+  unknown: 'An unknown exit status occurred.',
+};

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -10,5 +10,14 @@ void main() {
     test('Check some codes', () {
       expect(wrongUsage, 64);
     });
+
+    test('Check exitCodeDescriptions', () {
+      expect(exitCodeDescriptions, isA<Map<int, String>>());
+      expect(exitCodeDescriptions[success], 'The operation was successful.');
+      expect(exitCodeDescriptions[wrongUsage],
+          'The command line usage is incorrect.');
+      expect(exitCodeDescriptions[unknown], 'An unknown exit status occurred.');
+      expect(exitCodeDescriptions.length, 19);
+    });
   });
 }


### PR DESCRIPTION
This PR adds a `const Map<int, String> exitCodeDescriptions` to `lib/src/all_exit_codes_consts.dart` that maps exit code constants to their human-readable descriptions.

It also includes a test in `test/all_exit_codes_test.dart` to verify the map's correctness.

This improvement allows users to easily retrieve a description for a given exit code, enhancing the usability of the library.

---
*PR created automatically by Jules for task [12812108280331769512](https://jules.google.com/task/12812108280331769512) started by @insign*