### PR TITLE
Add exitCodeDescriptions map for human-readable exit code descriptions

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -54,3 +54,26 @@ const int userTerminated = 130;
 
 /// 255 - Unknown - An unknown exit status occurred.
 const int unknown = 255;
+
+/// Map of exit codes to their descriptions.
+const Map<int, String> exitCodeDescriptions = {
+  success: 'The operation was successful.',
+  generalError: 'An error that occurred during the operation.',
+  misuseOfShellBuiltins: 'The command line usage is incorrect.',
+  notADirectory: 'The specified path is not a directory.',
+  wrongUsage: 'The command line usage is incorrect.',
+  unableToOpenInputFile: 'The specified input file could not be opened.',
+  fileExists: 'The specified file already exists.',
+  unableToCreateTemporaryFile: 'A temporary file could not be created.',
+  unableToOpenOutputFile: 'The specified output file could not be opened.',
+  unableToOpenOutputFileForWriting: 'The specified output file could not be opened for writing.',
+  unableToOpenOutputFileForReading: 'The specified output file could not be opened for reading.',
+  ioError: 'An input/output error occurred.',
+  tryAgain: 'A temporary failure occurred, try again later.',
+  configurationError: 'A configuration error occurred.',
+  cantExecute: 'The command invoked cannot execute.',
+  notFound: 'The command was not found.',
+  invalidArgumentToExit: 'An invalid argument was passed to the exit command.',
+  userTerminated: 'The script was terminated by the user.',
+  unknown: 'An unknown exit status occurred.',
+};

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -10,5 +10,13 @@ void main() {
     test('Check some codes', () {
       expect(wrongUsage, 64);
     });
+
+    test('Check exitCodeDescriptions map', () {
+      expect(exitCodeDescriptions, isA<Map<int, String>>());
+      expect(exitCodeDescriptions[success], 'The operation was successful.');
+      expect(exitCodeDescriptions[wrongUsage], 'The command line usage is incorrect.');
+      expect(exitCodeDescriptions[notFound], 'The command was not found.');
+      expect(exitCodeDescriptions.length, 19);
+    });
   });
 }


### PR DESCRIPTION
Suggested improvement: Add a map of exit codes to their descriptions. This allows users to easily get a human-readable string for a given exit code, which is useful for logging and error reporting. This change adds the `exitCodeDescriptions` map to `lib/src/all_exit_codes_consts.dart` and includes unit tests to verify its correctness.

---
*PR created automatically by Jules for task [18374140986565211758](https://jules.google.com/task/18374140986565211758) started by @insign*