### PR TITLE
feat: Add exitCodeDescriptions map

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -54,3 +54,26 @@ const int userTerminated = 130;
 
 /// 255 - Unknown - An unknown exit status occurred.
 const int unknown = 255;
+
+/// Map of exit codes to their descriptions.
+const Map<int, String> exitCodeDescriptions = {
+  success: 'Success',
+  generalError: 'GeneralError',
+  misuseOfShellBuiltins: 'MisuseOfShellBuiltins',
+  notADirectory: 'NotADirectory',
+  wrongUsage: 'WrongUsage',
+  unableToOpenInputFile: 'UnableToOpenInputFile',
+  fileExists: 'FileExists',
+  unableToCreateTemporaryFile: 'UnableToCreateTemporaryFile',
+  unableToOpenOutputFile: 'UnableToOpenOutputFile',
+  unableToOpenOutputFileForWriting: 'UnableToOpenOutputFileForWriting',
+  unableToOpenOutputFileForReading: 'UnableToOpenOutputFileForReading',
+  ioError: 'IOError',
+  tryAgain: 'TryAgain',
+  configurationError: 'ConfigurationError',
+  cantExecute: 'CantExecute',
+  notFound: 'NotFound',
+  invalidArgumentToExit: 'InvalidArgumentToExit',
+  userTerminated: 'UserTerminated',
+  unknown: 'Unknown',
+};

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -10,5 +10,13 @@ void main() {
     test('Check some codes', () {
       expect(wrongUsage, 64);
     });
+
+    test('Check exitCodeDescriptions map', () {
+      expect(exitCodeDescriptions, isA<Map<int, String>>());
+      expect(exitCodeDescriptions[success], 'Success');
+      expect(exitCodeDescriptions[generalError], 'GeneralError');
+      expect(exitCodeDescriptions[wrongUsage], 'WrongUsage');
+      expect(exitCodeDescriptions.length, 19);
+    });
   });
 }


### PR DESCRIPTION
Added a `exitCodeDescriptions` map to `lib/src/all_exit_codes_consts.dart` to provide human-readable descriptions for exit codes.
Added a corresponding test case in `test/all_exit_codes_test.dart`.

---
*PR created automatically by Jules for task [2529589020546299470](https://jules.google.com/task/2529589020546299470) started by @insign*