### PR TITLE
Add ExitCodeExtension for int to easily access exit code descriptions

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -97,3 +97,9 @@ const Map<int, String> exitCodeDescriptions = {
   userTerminated: 'The script was terminated by the user.',
   unknown: 'An unknown exit status occurred.',
 };
+
+/// Extension to easily get the description of an exit code.
+extension ExitCodeExtension on int {
+  /// Returns the description of the exit code, or null if it is not a known exit code.
+  String? get exitDescription => exitCodeDescriptions[this];
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,11 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check ExitCodeExtension', () {
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(wrongUsage.exitDescription, 'The command line usage is incorrect.');
+      expect(12345.exitDescription, isNull);
+    });
   });
 }


### PR DESCRIPTION
This PR implements a quality-of-life improvement for the package by adding an extension on the `int` type. It provides the `exitDescription` property, allowing users to quickly access the human-readable description of an exit code directly from the integer constant, such as `success.exitDescription` or `wrongUsage.exitDescription`.

This is a safe and robust enhancement that does not break any existing contracts. Tests have been updated to ensure the feature operates correctly.

---
*PR created automatically by Jules for task [16429723123517363111](https://jules.google.com/task/16429723123517363111) started by @insign*