### PR TITLE
feat: Add ExitCodeExtension on int for exit code descriptions

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -97,3 +97,10 @@ const Map<int, String> exitCodeDescriptions = {
   userTerminated: 'The script was terminated by the user.',
   unknown: 'An unknown exit status occurred.',
 };
+
+/// Extension on [int] to easily get the exit code description.
+extension ExitCodeExtension on int {
+  /// Returns the human-readable description of the exit code.
+  String get exitDescription =>
+      exitCodeDescriptions[this] ?? exitCodeDescriptions[unknown]!;
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,13 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check exitDescription extension', () {
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(wrongUsage.exitDescription, 'The command line usage is incorrect.');
+      expect(noUser.exitDescription, 'The user specified did not exist.');
+      // Test unknown exit code
+      expect(999.exitDescription, 'An unknown exit status occurred.');
+    });
   });
 }


### PR DESCRIPTION
This adds a convenient Dart extension on `int` allowing developers to simply call `myExitCode.exitDescription` instead of using the `exitCodeDescriptions` map manually. Tests were updated to ensure it correctly returns descriptions for mapped codes and defaults to the 'unknown' description for unmapped integers.

---
*PR created automatically by Jules for task [10688078987936944856](https://jules.google.com/task/10688078987936944856) started by @insign*