### PR TITLE
feat: add ExitCodeExtension to int

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -97,3 +97,10 @@ const Map<int, String> exitCodeDescriptions = {
   userTerminated: 'The script was terminated by the user.',
   unknown: 'An unknown exit status occurred.',
 };
+
+/// Extension on [int] to easily access the human-readable description of an exit code.
+extension ExitCodeExtension on int {
+  /// Returns the human-readable description for this exit code.
+  /// If the code is not predefined, returns a generic "Unknown exit status." description.
+  String get exitDescription => exitCodeDescriptions[this] ?? 'Unknown exit status.';
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,14 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check ExitCodeExtension', () {
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(generalError.exitDescription, 'An error that occurred during the operation.');
+      expect(wrongUsage.exitDescription, 'The command line usage is incorrect.');
+      expect(dataError.exitDescription, 'The input data was incorrect in some way.');
+      expect(noUser.exitDescription, 'The user specified did not exist.');
+      expect(999.exitDescription, 'Unknown exit status.'); // Test missing code
+    });
   });
 }


### PR DESCRIPTION
Adds an extension to `int` that allows accessing the human-readable description of an exit code directly via the `.exitDescription` property. Also adds tests for this new extension.

---
*PR created automatically by Jules for task [7195811715570436084](https://jules.google.com/task/7195811715570436084) started by @insign*