### PR TITLE
feat: Add `ExitCodeExtension` to easily retrieve exit code descriptions

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -97,3 +97,9 @@ const Map<int, String> exitCodeDescriptions = {
   userTerminated: 'The script was terminated by the user.',
   unknown: 'An unknown exit status occurred.',
 };
+
+/// Extension on [int] to easily access the description string of an exit code.
+extension ExitCodeExtension on int {
+  /// Returns the human-readable description for this exit code.
+  String get exitDescription => exitCodeDescriptions[this] ?? 'Unknown exit code.';
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,12 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check ExitCodeExtension', () {
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(wrongUsage.exitDescription, 'The command line usage is incorrect.');
+      expect(noUser.exitDescription, 'The user specified did not exist.');
+      expect(999.exitDescription, 'Unknown exit code.');
+    });
   });
 }


### PR DESCRIPTION
Adiciona a extensão `ExitCodeExtension` no tipo `int` para permitir o acesso fácil à descrição de um código de saída através da propriedade `.exitDescription`. 

**Detalhes:**
- A extensão está implementada no arquivo `lib/src/all_exit_codes_consts.dart`.
- Adicionado testes no arquivo `test/all_exit_codes_test.dart` para garantir que o comportamento da nova propriedade `.exitDescription` atenda a todos os casos (códigos conhecidos e desconhecidos).
- Todos os testes (novos e antigos) passaram perfeitamente. Nenhuma quebra de código.
- Nenhuma adição de arquivos temporários.

Esta é uma melhoria simples que deixa a sintaxe da biblioteca muito mais idiomática e natural no Dart.

---
*PR created automatically by Jules for task [1326051449605128641](https://jules.google.com/task/1326051449605128641) started by @insign*