### PR TITLE
feat: add ExitCodeExtension for int

### DIFF
--- a/lib/all_exit_codes.dart
+++ b/lib/all_exit_codes.dart
@@ -4,3 +4,4 @@
 library;
 
 export 'src/all_exit_codes_consts.dart';
+export 'src/exit_code_extension.dart';

--- a/lib/src/exit_code_extension.dart
+++ b/lib/src/exit_code_extension.dart
@@ -1,0 +1,7 @@
+import 'all_exit_codes_consts.dart';
+
+/// Extension to easily get the human-readable description of an exit code
+extension ExitCodeExtension on int {
+  /// Returns the human-readable description of this exit code
+  String? get exitDescription => exitCodeDescriptions[this];
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,14 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check ExitCodeExtension', () {
+      expect(0.exitDescription, 'The operation was successful.');
+      expect(1.exitDescription, 'An error that occurred during the operation.');
+      expect(64.exitDescription, 'The command line usage is incorrect.');
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(generalError.exitDescription, 'An error that occurred during the operation.');
+      expect(999.exitDescription, isNull);
+    });
   });
 }


### PR DESCRIPTION
This PR adds an `ExitCodeExtension` on `int` to easily access the description string of an exit code directly via the `.exitDescription` property. This simplifies the usage of the `exitCodeDescriptions` map.

* Added `lib/src/exit_code_extension.dart` containing `ExitCodeExtension` with `exitDescription` getter.
* Exported the new extension in `lib/all_exit_codes.dart`.
* Added test cases for the extension in `test/all_exit_codes_test.dart` to verify known and unknown exit codes.

---
*PR created automatically by Jules for task [10017596765032707030](https://jules.google.com/task/10017596765032707030) started by @insign*