### PR TITLE
feat: Add ExitCodeExtension for int

### DIFF
--- a/lib/all_exit_codes.dart
+++ b/lib/all_exit_codes.dart
@@ -4,3 +4,4 @@
 library;
 
 export 'src/all_exit_codes_consts.dart';
+export 'src/exit_code_extension.dart';

--- a/lib/src/exit_code_extension.dart
+++ b/lib/src/exit_code_extension.dart
@@ -1,0 +1,7 @@
+import 'all_exit_codes_consts.dart';
+
+/// Extension to easily get the human-readable description of an exit code.
+extension ExitCodeExtension on int {
+  /// Returns the description of the exit code, or null if it is not a standard code.
+  String? get exitDescription => exitCodeDescriptions[this];
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,13 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check ExitCodeExtension', () {
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(generalError.exitDescription, 'An error that occurred during the operation.');
+      expect(wrongUsage.exitDescription, 'The command line usage is incorrect.');
+      expect(unknown.exitDescription, 'An unknown exit status occurred.');
+      expect(999.exitDescription, isNull);
+    });
   });
 }


### PR DESCRIPTION
This change introduces an `ExitCodeExtension` on the `int` type. This improves the package's ergonomics by allowing users to call `.exitDescription` directly on any integer representing an exit code, instead of manually accessing the `exitCodeDescriptions` map. This is purely additive and doesn't break existing behavior. Complete test coverage was added.

---
*PR created automatically by Jules for task [6665798646742287141](https://jules.google.com/task/6665798646742287141) started by @insign*