### PR TITLE
feat: add ExitCodeExtension for int to retrieve exit descriptions easily

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -97,3 +97,10 @@ const Map<int, String> exitCodeDescriptions = {
   userTerminated: 'The script was terminated by the user.',
   unknown: 'An unknown exit status occurred.',
 };
+
+/// Extension to easily get the human-readable description of an exit code.
+extension ExitCodeExtension on int {
+  /// Returns the human-readable description of this exit code.
+  String get exitDescription =>
+      exitCodeDescriptions[this] ?? 'An unknown exit status occurred.';
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,14 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check ExitCodeExtension', () {
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(generalError.exitDescription, 'An error that occurred during the operation.');
+      expect(wrongUsage.exitDescription, 'The command line usage is incorrect.');
+
+      // Test for an unknown exit code
+      expect(999.exitDescription, 'An unknown exit status occurred.');
+    });
   });
 }


### PR DESCRIPTION
Adds an `ExitCodeExtension` to easily get the human-readable description of an exit code directly from an integer, for example: `64.exitDescription`. It also includes tests to verify this extension behaves as expected for known codes and gracefully handles unknown exit codes.

---
*PR created automatically by Jules for task [9810485897557253231](https://jules.google.com/task/9810485897557253231) started by @insign*