### PR TITLE
feat: Add ExitCodeExtension for simplified exit description access

### DIFF
--- a/lib/all_exit_codes.dart
+++ b/lib/all_exit_codes.dart
@@ -4,3 +4,4 @@
 library;
 
 export 'src/all_exit_codes_consts.dart';
+export 'src/exit_code_extension.dart';

--- a/lib/src/exit_code_extension.dart
+++ b/lib/src/exit_code_extension.dart
@@ -1,0 +1,8 @@
+import 'all_exit_codes_consts.dart';
+
+/// Extension to easily access human-readable descriptions for exit codes.
+extension ExitCodeExtension on int {
+  /// Returns the human-readable description of the exit code.
+  /// If the exit code is not found, returns null.
+  String? get exitDescription => exitCodeDescriptions[this];
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,15 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check ExitCodeExtension', () {
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(wrongUsage.exitDescription, 'The command line usage is incorrect.');
+      expect(dataError.exitDescription, 'The input data was incorrect in some way.');
+
+      // Check unknown code
+      int myUnknownCode = 999;
+      expect(myUnknownCode.exitDescription, isNull);
+    });
   });
 }


### PR DESCRIPTION
This pull request adds an `ExitCodeExtension` on the `int` type to retrieve the human-readable description (`exitDescription`) of the exit code. This provides a simpler and more fluent way to retrieve descriptions compared to accessing the map manually. The extension is exported in the main `all_exit_codes.dart` file. Tests have been added to verify that `exitDescription` returns the correct values for known exit codes and `null` for unknown ones.

---
*PR created automatically by Jules for task [1248581382887106802](https://jules.google.com/task/1248581382887106802) started by @insign*