### PR TITLE
feat: add `.exitDescription` extension on int

### DIFF
--- a/lib/all_exit_codes.dart
+++ b/lib/all_exit_codes.dart
@@ -4,3 +4,4 @@
 library;
 
 export 'src/all_exit_codes_consts.dart';
+export 'src/exit_code_extension.dart';

--- a/lib/src/exit_code_extension.dart
+++ b/lib/src/exit_code_extension.dart
@@ -1,0 +1,10 @@
+import 'all_exit_codes_consts.dart';
+
+/// Adds utility methods to `int` representing exit codes.
+extension ExitCodeExtension on int {
+  /// Returns the human-readable description for this exit code.
+  /// If the code is not recognized, it returns a default "Unknown exit code" message.
+  String get exitDescription {
+    return exitCodeDescriptions[this] ?? 'An unknown exit status occurred.';
+  }
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,12 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check exitDescription extension on int', () {
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(wrongUsage.exitDescription, 'The command line usage is incorrect.');
+      expect(unknown.exitDescription, 'An unknown exit status occurred.');
+      expect(999.exitDescription, 'An unknown exit status occurred.');
+    });
   });
 }


### PR DESCRIPTION
Adiciona a extensão `ExitCodeExtension` em `int` que disponibiliza a propriedade `exitDescription`, retornando a string do mapa `exitCodeDescriptions` ou um status de fallback. A extensão foi exportada no `all_exit_codes.dart` e os devidos testes foram adicionados e executados com sucesso.

---
*PR created automatically by Jules for task [3680064265366995258](https://jules.google.com/task/3680064265366995258) started by @insign*