### PR TITLE
feat: add ExitCodeExtension for int to easily access exit descriptions

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -97,3 +97,11 @@ const Map<int, String> exitCodeDescriptions = {
   userTerminated: 'The script was terminated by the user.',
   unknown: 'An unknown exit status occurred.',
 };
+
+/// Extension to easily access the description string of an exit code directly.
+extension ExitCodeExtension on int {
+  /// Returns the description of the exit code. If the exit code is not found,
+  /// it returns 'Unknown exit code $this.'.
+  String get exitDescription =>
+      exitCodeDescriptions[this] ?? 'Unknown exit code $this.';
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,16 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check ExitCodeExtension', () {
+      expect(0.exitDescription, 'The operation was successful.');
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(64.exitDescription, 'The command line usage is incorrect.');
+      expect(wrongUsage.exitDescription, 'The command line usage is incorrect.');
+
+      // Test unknown exit code fallback
+      expect(999.exitDescription, 'Unknown exit code 999.');
+      expect((-1).exitDescription, 'Unknown exit code -1.');
+    });
   });
 }


### PR DESCRIPTION
This PR adds a quality of life improvement by introducing an `ExitCodeExtension` on the `int` type. It enables developers to access the exit code descriptions directly using `.exitDescription` on integer values or constants (e.g. `success.exitDescription` or `64.exitDescription`), improving code readability and developer experience. Fallback for unknown codes is also handled gracefully.

---
*PR created automatically by Jules for task [14120496750334973013](https://jules.google.com/task/14120496750334973013) started by @insign*