### PR TITLE
feat: add ExitCodeExtension for int

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -97,3 +97,9 @@ const Map<int, String> exitCodeDescriptions = {
   userTerminated: 'The script was terminated by the user.',
   unknown: 'An unknown exit status occurred.',
 };
+
+/// Extension to easily access the description string of an exit code directly via the `.exitDescription` property.
+extension ExitCodeExtension on int {
+  /// Returns the human-readable description of the exit code.
+  String get exitDescription => exitCodeDescriptions[this] ?? 'Unknown exit code';
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,13 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check ExitCodeExtension', () {
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(wrongUsage.exitDescription, 'The command line usage is incorrect.');
+      expect(unknown.exitDescription, 'An unknown exit status occurred.');
+      expect(999.exitDescription, 'Unknown exit code');
+      expect((-1).exitDescription, 'Unknown exit code');
+    });
   });
 }


### PR DESCRIPTION
This adds a useful feature by exposing an `ExitCodeExtension` on the `int` type. This enables accessing the description directly via a getter `exitDescription`, e.g. `wrongUsage.exitDescription` or `64.exitDescription`. It also includes fallback behavior for unknown codes.

---
*PR created automatically by Jules for task [16343645852145090577](https://jules.google.com/task/16343645852145090577) started by @insign*