### PR TITLE
feat: add ExitCodeExtension to retrieve descriptions easily

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -97,3 +97,11 @@ const Map<int, String> exitCodeDescriptions = {
   userTerminated: 'The script was terminated by the user.',
   unknown: 'An unknown exit status occurred.',
 };
+
+/// Extension to easily access the description string of an exit code.
+extension ExitCodeExtension on int {
+  /// Returns the human-readable description for this exit code.
+  /// If the exit code is not known, returns 'Unknown exit code.'
+  String get exitDescription =>
+      exitCodeDescriptions[this] ?? 'Unknown exit code.';
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,11 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check ExitCodeExtension', () {
+      expect(wrongUsage.exitDescription, 'The command line usage is incorrect.');
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(999.exitDescription, 'Unknown exit code.');
+    });
   });
 }


### PR DESCRIPTION
This PR adds a quality-of-life improvement by adding an `ExitCodeExtension` on `int`. This enables developers to do things like `wrongUsage.exitDescription` or `999.exitDescription` directly on integer exit codes. It falls back to a default 'Unknown exit code.' message if the code isn't tracked in the `exitCodeDescriptions` map. Tests have also been added to verify functionality.

---
*PR created automatically by Jules for task [9676274835001984728](https://jules.google.com/task/9676274835001984728) started by @insign*