### PR TITLE
feat: add ExitCodeExtension on int

### DIFF
--- a/lib/all_exit_codes.dart
+++ b/lib/all_exit_codes.dart
@@ -4,3 +4,4 @@
 library;
 
 export 'src/all_exit_codes_consts.dart';
+export 'src/exit_code_extension.dart';

--- a/lib/src/exit_code_extension.dart
+++ b/lib/src/exit_code_extension.dart
@@ -1,0 +1,8 @@
+import 'all_exit_codes_consts.dart';
+
+/// Extension to add [exitDescription] property to [int].
+extension ExitCodeExtension on int {
+  /// Returns the description string of this exit code using the [exitCodeDescriptions] map.
+  /// If the exit code is not found, returns `null` or a generic description.
+  String? get exitDescription => exitCodeDescriptions[this];
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,12 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check ExitCodeExtension', () {
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(wrongUsage.exitDescription, 'The command line usage is incorrect.');
+      expect(255.exitDescription, 'An unknown exit status occurred.');
+      expect(999.exitDescription, isNull);
+    });
   });
 }


### PR DESCRIPTION
Added `ExitCodeExtension` to easily retrieve exit descriptions. This is a single, clear improvement as requested, accompanied by relevant tests.

---
*PR created automatically by Jules for task [12950323282465160824](https://jules.google.com/task/12950323282465160824) started by @insign*