### PR TITLE
feat: add ExitCodeExtension on int

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -97,3 +97,12 @@ const Map<int, String> exitCodeDescriptions = {
   userTerminated: 'The script was terminated by the user.',
   unknown: 'An unknown exit status occurred.',
 };
+
+/// Extension on [int] to easily access the human-readable description of an exit code.
+extension ExitCodeExtension on int {
+  /// Returns the human-readable description of this exit code.
+  /// If the exit code is not found in [exitCodeDescriptions], it returns
+  /// the description for [unknown].
+  String get exitDescription =>
+      exitCodeDescriptions[this] ?? exitCodeDescriptions[unknown]!;
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,15 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check ExitCodeExtension', () {
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(wrongUsage.exitDescription, 'The command line usage is incorrect.');
+      expect(255.exitDescription, 'An unknown exit status occurred.');
+
+      // Test unknown exit codes
+      expect(999.exitDescription, 'An unknown exit status occurred.');
+      expect((-1).exitDescription, 'An unknown exit status occurred.');
+    });
   });
 }


### PR DESCRIPTION
Implementada a melhoria sugerida: Adicionar uma extension `ExitCodeExtension` em `int` para que os desenvolvedores possam obter a descrição de um exit code de forma fácil (ex: `success.exitDescription`). Adicionados e verificados testes apropriados para cobrir essa nova funcionalidade e garantir a correta cobertura para códigos conhecidos e desconhecidos. Análise estática com `dart analyze` e bateria de testes rodados sem erros. Nenhuma adição de arquivo temporário foi realizada.

---
*PR created automatically by Jules for task [11777074022867228688](https://jules.google.com/task/11777074022867228688) started by @insign*