### PR TITLE
feat: add ExitCodeExtension for int

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -97,3 +97,9 @@ const Map<int, String> exitCodeDescriptions = {
   userTerminated: 'The script was terminated by the user.',
   unknown: 'An unknown exit status occurred.',
 };
+
+/// Extension to easily get the exit code description from an integer.
+extension ExitCodeExtension on int {
+  /// Returns the description of the exit code, or null if it's not known.
+  String? get exitDescription => exitCodeDescriptions[this];
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,11 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check ExitCodeExtension', () {
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(wrongUsage.exitDescription, 'The command line usage is incorrect.');
+      expect(999.exitDescription, isNull);
+    });
   });
 }


### PR DESCRIPTION
Introduces an `ExitCodeExtension` on `int` to easily retrieve the corresponding human-readable description for an exit code.

---
*PR created automatically by Jules for task [2521911852245405946](https://jules.google.com/task/2521911852245405946) started by @insign*