### PR TITLE
feat: add ExitCodeExtension on int to easily access exit code descriptions

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -97,3 +97,11 @@ const Map<int, String> exitCodeDescriptions = {
   userTerminated: 'The script was terminated by the user.',
   unknown: 'An unknown exit status occurred.',
 };
+
+/// Extension on [int] to easily access the description of an exit code.
+extension ExitCodeExtension on int {
+  /// Returns the human-readable description corresponding to the exit code.
+  /// If the exit code is not found, returns the description for [unknown].
+  String get exitDescription =>
+      exitCodeDescriptions[this] ?? exitCodeDescriptions[unknown]!;
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,12 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check ExitCodeExtension', () {
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(wrongUsage.exitDescription, 'The command line usage is incorrect.');
+      expect(dataError.exitDescription, 'The input data was incorrect in some way.');
+      expect(999.exitDescription, 'An unknown exit status occurred.');
+    });
   });
 }


### PR DESCRIPTION
feat: add ExitCodeExtension on int to easily access exit code descriptions

This commit adds `ExitCodeExtension` on the `int` type in `all_exit_codes_consts.dart` to allow retrieving the human-readable description string of an exit code directly via `.exitDescription`. Appropriate unit tests have also been included in `all_exit_codes_test.dart` to ensure its expected behavior, including the fallback for unknown error codes.

---
*PR created automatically by Jules for task [12280785321323658623](https://jules.google.com/task/12280785321323658623) started by @insign*