### PR TITLE
feat: add `ExitCodeExtension` on `int` for easy access to exit descriptions

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -97,3 +97,11 @@ const Map<int, String> exitCodeDescriptions = {
   userTerminated: 'The script was terminated by the user.',
   unknown: 'An unknown exit status occurred.',
 };
+
+/// Extension to easily get the description of an exit code directly from the integer value.
+extension ExitCodeExtension on int {
+  /// Returns the human-readable description for this exit code,
+  /// or a default unknown message if the exit code is not recognized.
+  String get exitDescription =>
+      exitCodeDescriptions[this] ?? 'Unknown exit code: $this';
+}

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -28,5 +28,14 @@ void main() {
       expect(exitCodeDescriptions[noUser], 'The user specified did not exist.');
       expect(exitCodeDescriptions.length, 24);
     });
+
+    test('Check ExitCodeExtension', () {
+      expect(success.exitDescription, 'The operation was successful.');
+      expect(generalError.exitDescription, 'An error that occurred during the operation.');
+      expect(wrongUsage.exitDescription, 'The command line usage is incorrect.');
+
+      // Test unmapped code fallback
+      expect(999.exitDescription, 'Unknown exit code: 999');
+    });
   });
 }


### PR DESCRIPTION
Adicionei a `ExitCodeExtension` para facilitar o uso dos códigos de retorno, possibilitando que o desenvolvedor chame diretamente no número inteiro: `success.exitDescription` para receber a descrição correspondente. Todos os testes foram ajustados e passam.

---
*PR created automatically by Jules for task [17161101859389651579](https://jules.google.com/task/17161101859389651579) started by @insign*