### PR TITLE
feat: add isSuccess and isError getters to ExitCodeExtension

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -105,4 +105,10 @@ const Map<int, String> exitCodeDescriptions = {
 extension ExitCodeExtension on int {
   String get exitDescription =>
       exitCodeDescriptions[this] ?? 'Unknown exit code: $this';
+
+  /// Returns true if the exit code is [success] (0).
+  bool get isSuccess => this == success;
+
+  /// Returns true if the exit code is not [success] (0).
+  bool get isError => this != success;
 }

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -40,10 +40,14 @@ void main() {
 
     test('Check ExitCodeExtension', () {
       expect(success.exitDescription, 'The operation was successful.');
+      expect(success.isSuccess, isTrue);
+      expect(success.isError, isFalse);
       expect(
         generalError.exitDescription,
         'An error that occurred during the operation.',
       );
+      expect(generalError.isSuccess, isFalse);
+      expect(generalError.isError, isTrue);
       expect(
         wrongUsage.exitDescription,
         'The command line usage is incorrect.',


### PR DESCRIPTION
This pull request adds `isSuccess` and `isError` getters to the `ExitCodeExtension` on `int` to allow easily checking if an exit code is equal to `success` (0) or not. It also adds tests to cover these new getters.

---
*PR created automatically by Jules for task [9856013163326653798](https://jules.google.com/task/9856013163326653798) started by @insign*