### PR TITLE
feat: Add isSuccess and isError getters to ExitCodeExtension

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -105,4 +105,7 @@ const Map<int, String> exitCodeDescriptions = {
 extension ExitCodeExtension on int {
   String get exitDescription =>
       exitCodeDescriptions[this] ?? 'Unknown exit code: $this';
+
+  bool get isSuccess => this == success;
+  bool get isError => this != success;
 }

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -40,15 +40,26 @@ void main() {
 
     test('Check ExitCodeExtension', () {
       expect(success.exitDescription, 'The operation was successful.');
+      expect(success.isSuccess, isTrue);
+      expect(success.isError, isFalse);
+
       expect(
         generalError.exitDescription,
         'An error that occurred during the operation.',
       );
+      expect(generalError.isSuccess, isFalse);
+      expect(generalError.isError, isTrue);
+
       expect(
         wrongUsage.exitDescription,
         'The command line usage is incorrect.',
       );
+      expect(wrongUsage.isSuccess, isFalse);
+      expect(wrongUsage.isError, isTrue);
+
       expect(999.exitDescription, 'Unknown exit code: 999');
+      expect(999.isSuccess, isFalse);
+      expect(999.isError, isTrue);
     });
   });
 }


### PR DESCRIPTION
feat: Add isSuccess and isError getters to ExitCodeExtension

This commit introduces `isSuccess` and `isError` boolean getters
to the `ExitCodeExtension` on `int`. This provides a more readable and
convenient way to check the status of an exit code directly from the
integer value.

Tests have been updated to verify the behavior of these new getters
across different exit code scenarios (success, specific errors,
and unknown errors).

---
*PR created automatically by Jules for task [13939645047461558282](https://jules.google.com/task/13939645047461558282) started by @insign*