### PR TITLE
feat: Add isSuccess and isError getters to ExitCodeExtension

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -105,4 +105,7 @@ const Map<int, String> exitCodeDescriptions = {
 extension ExitCodeExtension on int {
   String get exitDescription =>
       exitCodeDescriptions[this] ?? 'Unknown exit code: $this';
+
+  bool get isSuccess => this == success;
+  bool get isError => this != success;
 }

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -49,6 +49,15 @@ void main() {
         'The command line usage is incorrect.',
       );
       expect(999.exitDescription, 'Unknown exit code: 999');
+
+      expect(success.isSuccess, isTrue);
+      expect(success.isError, isFalse);
+
+      expect(generalError.isSuccess, isFalse);
+      expect(generalError.isError, isTrue);
+
+      expect(999.isSuccess, isFalse);
+      expect(999.isError, isTrue);
     });
   });
 }


### PR DESCRIPTION
Adicionei os getters booleanos `isSuccess` e `isError` à extensão `ExitCodeExtension` sobre `int`. 

Isso simplifica a verificação de códigos de saída, permitindo chamadas mais expressivas como `exitCode.isSuccess` ou `exitCode.isError`, ao invés de comparar manualmente com `success`. Também atualizei os testes unitários garantindo que continuam passando e validam essa nova melhoria.

---
*PR created automatically by Jules for task [6545131960586750081](https://jules.google.com/task/6545131960586750081) started by @insign*