### PR TITLE
feat: add isSuccess and isError getters to ExitCodeExtension

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -105,4 +105,7 @@ const Map<int, String> exitCodeDescriptions = {
 extension ExitCodeExtension on int {
   String get exitDescription =>
       exitCodeDescriptions[this] ?? 'Unknown exit code: $this';
+
+  bool get isSuccess => this == success;
+  bool get isError => this != success;
 }

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -49,6 +49,12 @@ void main() {
         'The command line usage is incorrect.',
       );
       expect(999.exitDescription, 'Unknown exit code: 999');
+
+      expect(success.isSuccess, isTrue);
+      expect(success.isError, isFalse);
+
+      expect(generalError.isSuccess, isFalse);
+      expect(generalError.isError, isTrue);
     });
   });
 }


### PR DESCRIPTION
## Melhoria Sugerida
Foram adicionados dois novos getters na `ExitCodeExtension`: `isSuccess` e `isError`. 

### Por que isso é uma melhoria?
Isso facilita muito a legibilidade do código de quem consome sua biblioteca. Em vez do desenvolvedor precisar importar a constante `success` e fazer `if (exitCode == success)`, ele agora pode simplesmente fazer:
```dart
if (exitCode.isSuccess) {
  // Faz algo
}
```
Isso torna o código do usuário final mais limpo, expressivo e idiomático do Dart.

### O que foi alterado:
1. `lib/src/all_exit_codes_consts.dart`: Adição de `bool get isSuccess` e `bool get isError` na extensão.
2. `test/all_exit_codes_test.dart`: Testes para verificar que os getters funcionam para cenários de sucesso e de erro.

Os testes foram rodados e validados em ambiente. Nenhuma quebra para código existente foi adicionada. Apenas uma melhoria foi sugerida e aplicada conforme pedido.

---
*PR created automatically by Jules for task [2295497096861494749](https://jules.google.com/task/2295497096861494749) started by @insign*