### PR TITLE
Add isSuccess and isError getters to ExitCodeExtension

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -105,4 +105,7 @@ const Map<int, String> exitCodeDescriptions = {
 extension ExitCodeExtension on int {
   String get exitDescription =>
       exitCodeDescriptions[this] ?? 'Unknown exit code: $this';
+
+  bool get isSuccess => this == success;
+  bool get isError => this != success;
 }

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -49,6 +49,13 @@ void main() {
         'The command line usage is incorrect.',
       );
       expect(999.exitDescription, 'Unknown exit code: 999');
+
+      expect(success.isSuccess, isTrue);
+      expect(success.isError, isFalse);
+      expect(generalError.isSuccess, isFalse);
+      expect(generalError.isError, isTrue);
+      expect(wrongUsage.isSuccess, isFalse);
+      expect(wrongUsage.isError, isTrue);
     });
   });
 }


### PR DESCRIPTION
Added `isSuccess` and `isError` getters to `ExitCodeExtension` to quickly check if an exit code represents success or failure. Also added tests to verify the behavior.

---
*PR created automatically by Jules for task [14849135853601657521](https://jules.google.com/task/14849135853601657521) started by @insign*