### PR TITLE
feat: add isSuccess and isError getters to ExitCodeExtension

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -105,4 +105,7 @@ const Map<int, String> exitCodeDescriptions = {
 extension ExitCodeExtension on int {
   String get exitDescription =>
       exitCodeDescriptions[this] ?? 'Unknown exit code: $this';
+
+  bool get isSuccess => this == success;
+  bool get isError => this != success;
 }

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -50,5 +50,16 @@ void main() {
       );
       expect(999.exitDescription, 'Unknown exit code: 999');
     });
+
+    test('Check ExitCodeExtension isSuccess and isError', () {
+      expect(success.isSuccess, isTrue);
+      expect(success.isError, isFalse);
+
+      expect(generalError.isSuccess, isFalse);
+      expect(generalError.isError, isTrue);
+
+      expect(wrongUsage.isSuccess, isFalse);
+      expect(wrongUsage.isError, isTrue);
+    });
   });
 }


### PR DESCRIPTION
Added `isSuccess` and `isError` to `ExitCodeExtension` to make checking exit code status easier and more semantic. Included tests to verify.

---
*PR created automatically by Jules for task [15194466111977270321](https://jules.google.com/task/15194466111977270321) started by @insign*