### PR TITLE
feat: Add isSuccess and isError getters to ExitCodeExtension

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -105,4 +105,7 @@ const Map<int, String> exitCodeDescriptions = {
 extension ExitCodeExtension on int {
   String get exitDescription =>
       exitCodeDescriptions[this] ?? 'Unknown exit code: $this';
+
+  bool get isSuccess => this == success;
+  bool get isError => this != success;
 }

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -50,5 +50,19 @@ void main() {
       );
       expect(999.exitDescription, 'Unknown exit code: 999');
     });
+
+    test('Check isSuccess and isError', () {
+      expect(success.isSuccess, isTrue);
+      expect(success.isError, isFalse);
+
+      expect(generalError.isSuccess, isFalse);
+      expect(generalError.isError, isTrue);
+
+      expect(wrongUsage.isSuccess, isFalse);
+      expect(wrongUsage.isError, isTrue);
+
+      expect(999.isSuccess, isFalse);
+      expect(999.isError, isTrue);
+    });
   });
 }


### PR DESCRIPTION
Added `isSuccess` and `isError` getters to `ExitCodeExtension` to easily evaluate the status of an exit code directly from the integer. This allows for cleaner code like `if (code.isSuccess)` rather than `if (code == success)`.

Changes included:
- Added `isSuccess` and `isError` to `lib/src/all_exit_codes_consts.dart`.
- Added tests for `isSuccess` and `isError` in `test/all_exit_codes_test.dart` to cover success, known errors, and unknown codes.
- Verified changes with `dart test` to ensure they do not introduce any breakages.

---
*PR created automatically by Jules for task [13975173944578737307](https://jules.google.com/task/13975173944578737307) started by @insign*