### PR TITLE
feat: add isSuccess and isError getters to ExitCodeExtension

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -105,4 +105,7 @@ const Map<int, String> exitCodeDescriptions = {
 extension ExitCodeExtension on int {
   String get exitDescription =>
       exitCodeDescriptions[this] ?? 'Unknown exit code: $this';
+
+  bool get isSuccess => this == success;
+  bool get isError => this != success;
 }

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -50,5 +50,16 @@ void main() {
       );
       expect(999.exitDescription, 'Unknown exit code: 999');
     });
+
+    test('Check isSuccess and isError getters', () {
+      expect(success.isSuccess, isTrue);
+      expect(success.isError, isFalse);
+
+      expect(generalError.isSuccess, isFalse);
+      expect(generalError.isError, isTrue);
+
+      expect(wrongUsage.isSuccess, isFalse);
+      expect(wrongUsage.isError, isTrue);
+    });
   });
 }


### PR DESCRIPTION
This PR adds two convenient getters to `ExitCodeExtension`: `isSuccess` and `isError`. 

*   `isSuccess` returns `true` if the integer exit code is equal to `success` (0).
*   `isError` returns `true` if the integer exit code is anything other than `success` (0).

These additions make checking the status of an exit code more ergonomic and expressive. Tests were added to ensure the correct behavior.

---
*PR created automatically by Jules for task [581499291781067487](https://jules.google.com/task/581499291781067487) started by @insign*