### PR TITLE
Add `isSuccess` and `isError` getters to `ExitCodeExtension`

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -105,4 +105,10 @@ const Map<int, String> exitCodeDescriptions = {
 extension ExitCodeExtension on int {
   String get exitDescription =>
       exitCodeDescriptions[this] ?? 'Unknown exit code: $this';
+
+  /// Returns `true` if the exit code is [success] (0).
+  bool get isSuccess => this == success;
+
+  /// Returns `true` if the exit code is not [success] (0).
+  bool get isError => this != success;
 }

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -49,6 +49,15 @@ void main() {
         'The command line usage is incorrect.',
       );
       expect(999.exitDescription, 'Unknown exit code: 999');
+
+      expect(success.isSuccess, isTrue);
+      expect(success.isError, isFalse);
+
+      expect(generalError.isSuccess, isFalse);
+      expect(generalError.isError, isTrue);
+
+      expect(999.isSuccess, isFalse);
+      expect(999.isError, isTrue);
     });
   });
 }


### PR DESCRIPTION
Added `isSuccess` and `isError` boolean getters to `ExitCodeExtension` to easily check if an exit code represents success or an error. Added corresponding tests.

---
*PR created automatically by Jules for task [14459954847656910540](https://jules.google.com/task/14459954847656910540) started by @insign*