### PR TITLE
fix: update codes 66-73 to standard BSD sysexits.h names

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -4,7 +4,7 @@ const int success = 0;
 /// 1 - GeneralError - An error that occurred during the operation.
 const int generalError = 1;
 
-/// 2 - MisuseOfShellBuiltins - The command line usage is incorrect.
+/// 2 - MisuseOfShellBuiltins - Misuse of shell builtins.
 const int misuseOfShellBuiltins = 2;
 
 /// 20 - NotADirectory - The specified path is not a directory.
@@ -17,7 +17,11 @@ const int wrongUsage = 64;
 const int dataError = 65;
 
 /// 66 - UnableToOpenInputFile - The specified input file could not be opened.
+@Deprecated('Use noInput instead')
 const int unableToOpenInputFile = 66;
+
+/// 66 - NoInput - An input file (not a system file) did not exist or was not readable.
+const int noInput = 66;
 
 /// 67 - NoUser - The user specified did not exist.
 const int noUser = 67;
@@ -26,19 +30,39 @@ const int noUser = 67;
 const int noHost = 68;
 
 /// 72 - FileExists - The specified file already exists.
+@Deprecated('Use osFile instead')
 const int fileExists = 72;
 
+/// 72 - OSFile - Some system file does not exist, cannot be opened, or has some sort of error.
+const int osFile = 72;
+
 /// 73 - UnableToCreateTemporaryFile - A temporary file could not be created.
+@Deprecated('Use cantCreate instead')
 const int unableToCreateTemporaryFile = 73;
 
+/// 73 - CantCreate - A (user specified) output file cannot be created.
+const int cantCreate = 73;
+
 /// 69 - UnableToOpenOutputFile - The specified output file could not be opened.
+@Deprecated('Use unavailable instead')
 const int unableToOpenOutputFile = 69;
 
+/// 69 - Unavailable - A service is unavailable.
+const int unavailable = 69;
+
 /// 70 - UnableToOpenOutputFileForWriting - The specified output file could not be opened for writing.
+@Deprecated('Use software instead')
 const int unableToOpenOutputFileForWriting = 70;
 
+/// 70 - Software - An internal software error has been detected.
+const int software = 70;
+
 /// 71 - UnableToOpenOutputFileForReading - The specified output file could not be opened for reading.
+@Deprecated('Use osError instead')
 const int unableToOpenOutputFileForReading = 71;
+
+/// 71 - OSError - An operating system error has been detected.
+const int osError = 71;
 
 /// 74 - IOError - An input/output error occurred.
 const int ioError = 74;
@@ -74,20 +98,20 @@ const int unknown = 255;
 const Map<int, String> exitCodeDescriptions = {
   success: 'The operation was successful.',
   generalError: 'An error that occurred during the operation.',
-  misuseOfShellBuiltins: 'The command line usage is incorrect.',
+  misuseOfShellBuiltins: 'Misuse of shell builtins.',
   notADirectory: 'The specified path is not a directory.',
   wrongUsage: 'The command line usage is incorrect.',
   dataError: 'The input data was incorrect in some way.',
-  unableToOpenInputFile: 'The specified input file could not be opened.',
+  noInput:
+      'An input file (not a system file) did not exist or was not readable.',
   noUser: 'The user specified did not exist.',
   noHost: 'The host specified did not exist.',
-  fileExists: 'The specified file already exists.',
-  unableToCreateTemporaryFile: 'A temporary file could not be created.',
-  unableToOpenOutputFile: 'The specified output file could not be opened.',
-  unableToOpenOutputFileForWriting:
-      'The specified output file could not be opened for writing.',
-  unableToOpenOutputFileForReading:
-      'The specified output file could not be opened for reading.',
+  osFile:
+      'Some system file does not exist, cannot be opened, or has some sort of error.',
+  cantCreate: 'A (user specified) output file cannot be created.',
+  unavailable: 'A service is unavailable.',
+  software: 'An internal software error has been detected.',
+  osError: 'An operating system error has been detected.',
   ioError: 'An input/output error occurred.',
   tryAgain: 'A temporary failure occurred, try again later.',
   protocolError:

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -13,6 +13,12 @@ void main() {
 
     test('Check BSD exit codes', () {
       expect(dataError, 65);
+      expect(noInput, 66);
+      expect(unavailable, 69);
+      expect(software, 70);
+      expect(osError, 71);
+      expect(osFile, 72);
+      expect(cantCreate, 73);
       expect(noUser, 67);
       expect(noHost, 68);
       expect(protocolError, 76);
@@ -27,9 +33,24 @@ void main() {
         'An error that occurred during the operation.',
       );
       expect(
+        exitCodeDescriptions[misuseOfShellBuiltins],
+        'Misuse of shell builtins.',
+      );
+      expect(
         exitCodeDescriptions[wrongUsage],
         'The command line usage is incorrect.',
       );
+      expect(exitCodeDescriptions[noInput],
+          'An input file (not a system file) did not exist or was not readable.');
+      expect(exitCodeDescriptions[unavailable], 'A service is unavailable.');
+      expect(exitCodeDescriptions[software],
+          'An internal software error has been detected.');
+      expect(exitCodeDescriptions[osError],
+          'An operating system error has been detected.');
+      expect(exitCodeDescriptions[osFile],
+          'Some system file does not exist, cannot be opened, or has some sort of error.');
+      expect(exitCodeDescriptions[cantCreate],
+          'A (user specified) output file cannot be created.');
       expect(
         exitCodeDescriptions[dataError],
         'The input data was incorrect in some way.',


### PR DESCRIPTION
Esta PR corrige as constantes de códigos de saída 66 a 73, substituindo nomes não padronizados pelos nomes corretos definidos no padrão `sysexits.h` do POSIX/BSD. Isso melhora a confiabilidade da biblioteca, garantindo que os códigos retornados reflitam o padrão do sistema operacional, o que é genuinamente útil para integrações CLI mais precisas.

A mudança não quebra código existente, pois as constantes antigas foram mantidas e marcadas como `@Deprecated`, guiando os usuários para as constantes corretas sem erros de compilação.

### Mudanças Implementadas
- Atualização do arquivo `lib/src/all_exit_codes_consts.dart` deprecando nomes incorretos (ex: `unableToOpenInputFile`) para os nomes corretos do BSD (ex: `noInput`).
- Correção das descrições do mapa `exitCodeDescriptions` para refletirem os significados padrão.
- Correção de um typo de copiar-colar na descrição do código 2 (`misuseOfShellBuiltins`).
- Atualização dos testes em `test/all_exit_codes_test.dart` para validar as novas constantes e as descrições corrigidas.

### Testes
- Todos os testes continuam passando.
- Testes foram adicionados para cobrir as novas constantes `noInput`, `unavailable`, `software`, `osError`, `osFile`, e `cantCreate`.
- Testes atualizados para verificar as chaves correspondentes no `exitCodeDescriptions`.

---
*PR created automatically by Jules for task [14218573212785189303](https://jules.google.com/task/14218573212785189303) started by @insign*