### PR TITLE
feat: add exitProcess extension method for elegant termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ dart pub add all_exit_codes
 import 'package:all_exit_codes/all_exit_codes.dart';
 
 Never main() {
-  print('Maybe you are using this command wrong. Check the usage.');
-  exit(wrongUsage);
+  // Gracefully log to stderr and exit with code 64
+  wrongUsage.exitProcess('Maybe you are using this command wrong. Check the usage.');
 }
 ```
 

--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 /// 0 - Success - The operation was successful.
 const int success = 0;
 
@@ -133,4 +135,19 @@ extension ExitCodeExtension on int {
   bool get isSuccess => this == success;
 
   bool get isError => this != success;
+
+  /// Exits the process with this exit code.
+  ///
+  /// If [message] is provided, it is printed to stdout if the exit code is
+  /// [success], or to stderr if the exit code is an error.
+  /// If [message] is not provided, the [exitDescription] is printed instead.
+  Never exitProcess([String? message]) {
+    final msg = message ?? exitDescription;
+    if (isError) {
+      stderr.writeln(msg);
+    } else {
+      stdout.writeln(msg);
+    }
+    exit(this);
+  }
 }

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -1,10 +1,36 @@
+import 'dart:io';
 import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('A group of tests', () {
     setUp(() {
-      // Additional setup goes here.
+      final dir = Directory('test/temp');
+      if (!dir.existsSync()) {
+        dir.createSync();
+      }
+      File('test/temp/test_script.dart').writeAsStringSync('''
+import 'package:all_exit_codes/all_exit_codes.dart';
+
+void main(List<String> args) {
+  final isError = args[0] == 'error';
+  final hasMessage = args[1] == 'true';
+  final message = hasMessage ? 'Custom message' : null;
+
+  if (isError) {
+    wrongUsage.exitProcess(message);
+  } else {
+    success.exitProcess(message);
+  }
+}
+''');
+    });
+
+    tearDownAll(() {
+      final dir = Directory('test/temp');
+      if (dir.existsSync()) {
+        dir.deleteSync(recursive: true);
+      }
     });
 
     test('Check some codes', () {
@@ -82,6 +108,41 @@ void main() {
 
       expect(999.isSuccess, isFalse);
       expect(999.isError, isTrue);
+    });
+
+    test('Check exitProcess extension with custom message on error', () async {
+      final result = await Process.run(
+          'dart', ['run', 'test/temp/test_script.dart', 'error', 'true']);
+      expect(result.exitCode, wrongUsage);
+      expect(result.stdout.toString().trim(), isEmpty);
+      expect(result.stderr.toString().trim(), 'Custom message');
+    });
+
+    test('Check exitProcess extension with default message on error', () async {
+      final result = await Process.run(
+          'dart', ['run', 'test/temp/test_script.dart', 'error', 'false']);
+      expect(result.exitCode, wrongUsage);
+      expect(result.stdout.toString().trim(), isEmpty);
+      expect(result.stderr.toString().trim(),
+          'The command line usage is incorrect.');
+    });
+
+    test('Check exitProcess extension with custom message on success',
+        () async {
+      final result = await Process.run(
+          'dart', ['run', 'test/temp/test_script.dart', 'success', 'true']);
+      expect(result.exitCode, success);
+      expect(result.stderr.toString().trim(), isEmpty);
+      expect(result.stdout.toString().trim(), 'Custom message');
+    });
+
+    test('Check exitProcess extension with default message on success',
+        () async {
+      final result = await Process.run(
+          'dart', ['run', 'test/temp/test_script.dart', 'success', 'false']);
+      expect(result.exitCode, success);
+      expect(result.stderr.toString().trim(), isEmpty);
+      expect(result.stdout.toString().trim(), 'The operation was successful.');
     });
   });
 }


### PR DESCRIPTION
Este PR adiciona o método `exitProcess([String? message])` na extensão `ExitCodeExtension`, permitindo encerrar um script de CLI com uma única linha (ex: `wrongUsage.exitProcess('Erro fatal');`) que automaticamente imprime a mensagem via `stderr` (se erro) ou `stdout` (se sucesso) antes de chamar `exit()`. Isso é útil porque elimina o boilerplate de ter que importar `dart:io`, checar se é erro, imprimir e depois chamar `exit(code)` manualmente, melhorando muito a DX em scripts de terminal.

* **Implementação:** Foi adicionado o método na extensão em `lib/src/all_exit_codes_consts.dart`. O README foi atualizado para demonstrar o novo uso enxuto.
* **Testes:** Para assegurar que não faríamos commit de arquivos temporários, os testes usam `Process.run` com um arquivo gerado localmente no `setUp` e apagado no `tearDownAll`, validando os *exit codes* e *streams* (`stdout`/`stderr`) corretamente. O package `dart:io` foi importado apenas nas constantes onde ele é consumido.
* O processo foi todo validado com `dart format .`, `dart analyze` e `dart test`. Nenhuma quebra de testes e regras do linter respeitadas.

---
*PR created automatically by Jules for task [14958258954334909502](https://jules.google.com/task/14958258954334909502) started by @insign*