### PR TITLE
feat: Add `exitName` getter for structured logging and telemetry

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -128,9 +128,39 @@ const Map<int, String> exitCodeDescriptions = {
   unknown: 'An unknown exit status occurred.',
 };
 
+/// Map of exit codes to their symbolic names.
+const Map<int, String> exitCodeNames = {
+  success: 'success',
+  generalError: 'generalError',
+  misuseOfShellBuiltins: 'misuseOfShellBuiltins',
+  notADirectory: 'notADirectory',
+  wrongUsage: 'wrongUsage',
+  dataError: 'dataError',
+  noInput: 'noInput',
+  noUser: 'noUser',
+  noHost: 'noHost',
+  osFile: 'osFile',
+  cantCreate: 'cantCreate',
+  unavailable: 'unavailable',
+  software: 'software',
+  osError: 'osError',
+  ioError: 'ioError',
+  tryAgain: 'tryAgain',
+  protocolError: 'protocolError',
+  noPermission: 'noPermission',
+  configurationError: 'configurationError',
+  cantExecute: 'cantExecute',
+  notFound: 'notFound',
+  invalidArgumentToExit: 'invalidArgumentToExit',
+  userTerminated: 'userTerminated',
+  unknown: 'unknown',
+};
+
 extension ExitCodeExtension on int {
   String get exitDescription =>
       exitCodeDescriptions[this] ?? 'Unknown exit code: $this';
+
+  String get exitName => exitCodeNames[this] ?? 'unknown';
 
   bool get isSuccess => this == success;
 

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -144,5 +144,24 @@ void main(List<String> args) {
       expect(result.stderr.toString().trim(), isEmpty);
       expect(result.stdout.toString().trim(), 'The operation was successful.');
     });
+
+    test('Check exitCodeNames map', () {
+      expect(exitCodeNames, isA<Map<int, String>>());
+      expect(exitCodeNames[success], 'success');
+      expect(exitCodeNames[generalError], 'generalError');
+      expect(exitCodeNames[wrongUsage], 'wrongUsage');
+      expect(exitCodeNames[noInput], 'noInput');
+      expect(exitCodeNames[unavailable], 'unavailable');
+      expect(exitCodeNames[software], 'software');
+      expect(exitCodeNames.length, 24);
+    });
+
+    test('Check exitName extension', () {
+      expect(success.exitName, 'success');
+      expect(generalError.exitName, 'generalError');
+      expect(wrongUsage.exitName, 'wrongUsage');
+      expect(noInput.exitName, 'noInput');
+      expect(999.exitName, 'unknown');
+    });
   });
 }


### PR DESCRIPTION
Este PR introduz o map constante `exitCodeNames` e o getter `exitName` na `ExitCodeExtension` para associar códigos de saída em inteiros aos seus nomes simbólicos em string (ex: `success`, `wrongUsage`). Isso melhora consideravelmente a utilidade do pacote em sistemas de telemetria, logs estruturados e plataformas de monitoramento (como Datadog/Sentry) onde é essencial registrar os nomes dos eventos ao invés de códigos numéricos opacos ou frases inteiras verbosas contidas no `exitDescription`. Adicionalmente, implementamos testes extensivos para assegurar o funcionamento dos mapeamentos e fallback.

---
*PR created automatically by Jules for task [16227217222103423225](https://jules.google.com/task/16227217222103423225) started by @insign*