### PR TITLE
feat: Add `exitName` getter for symbolic exit code representations

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -128,7 +128,37 @@ const Map<int, String> exitCodeDescriptions = {
   unknown: 'An unknown exit status occurred.',
 };
 
+/// Map of exit codes to their symbolic names.
+const Map<int, String> exitCodeNames = {
+  success: 'success',
+  generalError: 'generalError',
+  misuseOfShellBuiltins: 'misuseOfShellBuiltins',
+  notADirectory: 'notADirectory',
+  wrongUsage: 'wrongUsage',
+  dataError: 'dataError',
+  noInput: 'noInput',
+  noUser: 'noUser',
+  noHost: 'noHost',
+  osFile: 'osFile',
+  cantCreate: 'cantCreate',
+  unavailable: 'unavailable',
+  software: 'software',
+  osError: 'osError',
+  ioError: 'ioError',
+  tryAgain: 'tryAgain',
+  protocolError: 'protocolError',
+  noPermission: 'noPermission',
+  configurationError: 'configurationError',
+  cantExecute: 'cantExecute',
+  notFound: 'notFound',
+  invalidArgumentToExit: 'invalidArgumentToExit',
+  userTerminated: 'userTerminated',
+  unknown: 'unknown',
+};
+
 extension ExitCodeExtension on int {
+  String get exitName => exitCodeNames[this] ?? 'unknown';
+
   String get exitDescription =>
       exitCodeDescriptions[this] ?? 'Unknown exit code: $this';
 

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -85,7 +85,29 @@ void main(List<String> args) {
       expect(exitCodeDescriptions.length, 24);
     });
 
+    test('Check exitCodeNames map', () {
+      expect(exitCodeNames, isA<Map<int, String>>());
+      expect(exitCodeNames[success], 'success');
+      expect(exitCodeNames[generalError], 'generalError');
+      expect(exitCodeNames[misuseOfShellBuiltins], 'misuseOfShellBuiltins');
+      expect(exitCodeNames[wrongUsage], 'wrongUsage');
+      expect(exitCodeNames[noInput], 'noInput');
+      expect(exitCodeNames[unavailable], 'unavailable');
+      expect(exitCodeNames[software], 'software');
+      expect(exitCodeNames[osError], 'osError');
+      expect(exitCodeNames[osFile], 'osFile');
+      expect(exitCodeNames[cantCreate], 'cantCreate');
+      expect(exitCodeNames[dataError], 'dataError');
+      expect(exitCodeNames[noUser], 'noUser');
+      expect(exitCodeNames.length, 24);
+    });
+
     test('Check ExitCodeExtension', () {
+      expect(success.exitName, 'success');
+      expect(generalError.exitName, 'generalError');
+      expect(wrongUsage.exitName, 'wrongUsage');
+      expect(999.exitName, 'unknown');
+
       expect(success.exitDescription, 'The operation was successful.');
       expect(
         generalError.exitDescription,


### PR DESCRIPTION
Este PR adiciona uma nova propriedade `exitName` para inteiros e o mapa `exitCodeNames` subjacente, permitindo resgatar o nome simbólico das constantes (ex: `success`, `generalError`). É útil em logs dinâmicos e depurações onde precisamos de uma representação direta do nome da constante ao invés de apenas um número.

Testes unitários foram adicionados e todos os testes existentes continuam passando normalmente. Nenhuma modificação disruptiva (breaking change) foi feita, apenas uma melhoria na utilidade da `ExitCodeExtension`.

---
*PR created automatically by Jules for task [7205963047393294168](https://jules.google.com/task/7205963047393294168) started by @insign*