### PR TITLE
feat: add ExitException and throwExit extension for graceful CLI process termination

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -180,4 +180,35 @@ extension ExitCodeExtension on int {
     }
     exit(this);
   }
+
+  /// Throws an [ExitException] with this exit code.
+  ///
+  /// This is useful in CLI architectures to bubble up an exit status gracefully
+  /// up the call stack instead of terminating the process immediately with
+  /// [exitProcess], making unit testing much easier.
+  Never throwExit([String? message]) {
+    throw ExitException(this, message);
+  }
+}
+
+/// An exception that wraps an exit code and an optional message.
+///
+/// This exception allows CLI applications to throw an exit status up the
+/// call stack and catch it at the top level to gracefully exit the process,
+/// avoiding hard exits deep within business logic which are difficult to test.
+class ExitException implements Exception {
+  /// The exit code.
+  final int exitCode;
+
+  /// The custom message provided, if any.
+  final String? message;
+
+  /// Creates a new [ExitException].
+  const ExitException(this.exitCode, [this.message]);
+
+  @override
+  String toString() {
+    final msg = message ?? exitCode.exitDescription;
+    return 'ExitException($exitCode): $msg';
+  }
 }

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -166,5 +166,39 @@ void main(List<String> args) {
       expect(result.stderr.toString().trim(), isEmpty);
       expect(result.stdout.toString().trim(), 'The operation was successful.');
     });
+
+    test('Check throwExit extension throws ExitException', () {
+      expect(
+        () => wrongUsage.throwExit(),
+        throwsA(isA<ExitException>()
+            .having((e) => e.exitCode, 'exitCode', wrongUsage)
+            .having((e) => e.message, 'message', isNull)
+            .having((e) => e.toString(), 'toString',
+                'ExitException(64): The command line usage is incorrect.')),
+      );
+
+      expect(
+        () => success.throwExit('All good!'),
+        throwsA(isA<ExitException>()
+            .having((e) => e.exitCode, 'exitCode', success)
+            .having((e) => e.message, 'message', 'All good!')
+            .having((e) => e.toString(), 'toString',
+                'ExitException(0): All good!')),
+      );
+    });
+
+    test('Check ExitException toString formats correctly', () {
+      final exceptionWithoutMessage = ExitException(generalError);
+      expect(exceptionWithoutMessage.toString(),
+          'ExitException(1): An error that occurred during the operation.');
+
+      final exceptionWithMessage = ExitException(notADirectory, 'Custom error');
+      expect(exceptionWithMessage.toString(),
+          'ExitException(20): Custom error');
+
+      final exceptionUnknown = ExitException(999);
+      expect(
+          exceptionUnknown.toString(), 'ExitException(999): Unknown exit code: 999');
+    });
   });
 }


### PR DESCRIPTION
This PR adiciona a classe `ExitException` e o método de extensão `throwExit()`, melhorando a testabilidade de aplicações CLI ao permitir que erros subam pela pilha de chamadas ao invés de forçar o encerramento imediato do processo.

**Por que isso é realmente útil?**
Em arquiteturas de CLI (Command Line Interface), chamar `exit()` diretamente nas camadas de lógica de negócio encerra imediatamente a execução, o que mata os runners de teste e torna o código impossível de ser testado unitariamente de forma isolada. A introdução do `ExitException` permite que os desenvolvedores substituam chamadas rígidas como `wrongUsage.exitProcess()` por `wrongUsage.throwExit()`. Isso possibilita que os testes unitários capturem a exceção e verifiquem se o fluxo gerou o código de erro correto sem interromper a suíte de testes. Em produção, a aplicação CLI captura a exceção no seu nível mais alto (`main()`) e realiza o encerramento final com o código adequado.

**Modificações:**
1. Foi adicionada a classe `ExitException` em `lib/src/all_exit_codes_consts.dart` que herda de `Exception` contendo o código de saída e uma mensagem.
2. Adicionado o método de extensão `throwExit([String? message])` ao longo do `ExitCodeExtension` já existente, permitindo lançar a exceção de forma sucinta.
3. Cobertura de testes abrangente adicionada em `test/all_exit_codes_test.dart` para validar que as exceções contêm as mensagens (customizadas e padrão) e os exit codes corretos quando disparadas.

---
*PR created automatically by Jules for task [16335942575223479809](https://jules.google.com/task/16335942575223479809) started by @insign*