### PR TITLE
feat: Support Object types for message parameters in exit extensions

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -171,8 +171,8 @@ extension ExitCodeExtension on int {
   /// If [message] is provided, it is printed to stdout if the exit code is
   /// [success], or to stderr if the exit code is an error.
   /// If [message] is not provided, the [exitDescription] is printed instead.
-  Never exitProcess([String? message]) {
-    final msg = message ?? exitDescription;
+  Never exitProcess([Object? message]) {
+    final msg = message?.toString() ?? exitDescription;
     if (isError) {
       stderr.writeln(msg);
     } else {
@@ -186,7 +186,7 @@ extension ExitCodeExtension on int {
   /// This is useful in CLI architectures to bubble up an exit status gracefully
   /// up the call stack instead of terminating the process immediately with
   /// [exitProcess], making unit testing much easier.
-  Never throwExit([String? message]) {
+  Never throwExit([Object? message]) {
     throw ExitException(this, message);
   }
 }
@@ -201,14 +201,14 @@ class ExitException implements Exception {
   final int exitCode;
 
   /// The custom message provided, if any.
-  final String? message;
+  final Object? message;
 
   /// Creates a new [ExitException].
   const ExitException(this.exitCode, [this.message]);
 
   @override
   String toString() {
-    final msg = message ?? exitCode.exitDescription;
+    final msg = message?.toString() ?? exitCode.exitDescription;
     return 'ExitException($exitCode): $msg';
   }
 }

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -15,7 +15,14 @@ import 'package:all_exit_codes/all_exit_codes.dart';
 void main(List<String> args) {
   final isError = args[0] == 'error';
   final hasMessage = args[1] == 'true';
-  final message = hasMessage ? 'Custom message' : null;
+  final isObject = args[1] == 'object';
+
+  Object? message;
+  if (hasMessage) {
+    message = 'Custom message';
+  } else if (isObject) {
+    message = Exception('Object message');
+  }
 
   if (isError) {
     wrongUsage.exitProcess(message);
@@ -140,6 +147,14 @@ void main(List<String> args) {
       expect(result.stderr.toString().trim(), 'Custom message');
     });
 
+    test('Check exitProcess extension with object message on error', () async {
+      final result = await Process.run(
+          'dart', ['run', 'test/temp/test_script.dart', 'error', 'object']);
+      expect(result.exitCode, wrongUsage);
+      expect(result.stdout.toString().trim(), isEmpty);
+      expect(result.stderr.toString().trim(), 'Exception: Object message');
+    });
+
     test('Check exitProcess extension with default message on error', () async {
       final result = await Process.run(
           'dart', ['run', 'test/temp/test_script.dart', 'error', 'false']);
@@ -184,6 +199,18 @@ void main(List<String> args) {
             .having((e) => e.message, 'message', 'All good!')
             .having((e) => e.toString(), 'toString',
                 'ExitException(0): All good!')),
+      );
+    });
+
+    test('Check throwExit extension throws ExitException with object message', () {
+      final exceptionObj = Exception('Object message');
+      expect(
+        () => wrongUsage.throwExit(exceptionObj),
+        throwsA(isA<ExitException>()
+            .having((e) => e.exitCode, 'exitCode', wrongUsage)
+            .having((e) => e.message, 'message', exceptionObj)
+            .having((e) => e.toString(), 'toString',
+                'ExitException(64): Exception: Object message')),
       );
     });
 


### PR DESCRIPTION
Este PR melhora a Developer Experience (DX) da API ao permitir a passagem direta de objetos (como instâncias de `Exception` ou `Error`) para `exitProcess` e `throwExit`, eliminando a necessidade de converter manualmente os erros para `.toString()` dentro de blocos `catch`. 

**Por que isso é útil?**
Em arquiteturas CLI, é comum lidar com exceções. Anteriormente, era necessário fazer `success.exitProcess(e.toString());`. Com esta atualização, pode-se simplesmente fazer `success.exitProcess(e);`, aproximando a API das práticas padrões do Dart, como a função `print()`. A mudança é 100% retrocompatível, mantendo o fallback para descrições padrão quando a mensagem for nula. Além disso, foram adicionados testes abrangentes que garantem o suporte nativo a objetos.

---
*PR created automatically by Jules for task [6457508760364440290](https://jules.google.com/task/6457508760364440290) started by @insign*