### PR TITLE
feat: accept Object? as message in ExitCodeExtension and ExitException

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -171,8 +171,8 @@ extension ExitCodeExtension on int {
   /// If [message] is provided, it is printed to stdout if the exit code is
   /// [success], or to stderr if the exit code is an error.
   /// If [message] is not provided, the [exitDescription] is printed instead.
-  Never exitProcess([String? message]) {
-    final msg = message ?? exitDescription;
+  Never exitProcess([Object? message]) {
+    final msg = message?.toString() ?? exitDescription;
     if (isError) {
       stderr.writeln(msg);
     } else {
@@ -186,7 +186,7 @@ extension ExitCodeExtension on int {
   /// This is useful in CLI architectures to bubble up an exit status gracefully
   /// up the call stack instead of terminating the process immediately with
   /// [exitProcess], making unit testing much easier.
-  Never throwExit([String? message]) {
+  Never throwExit([Object? message]) {
     throw ExitException(this, message);
   }
 }
@@ -201,14 +201,14 @@ class ExitException implements Exception {
   final int exitCode;
 
   /// The custom message provided, if any.
-  final String? message;
+  final Object? message;
 
   /// Creates a new [ExitException].
   const ExitException(this.exitCode, [this.message]);
 
   @override
   String toString() {
-    final msg = message ?? exitCode.exitDescription;
+    final msg = message?.toString() ?? exitCode.exitDescription;
     return 'ExitException($exitCode): $msg';
   }
 }

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -200,5 +200,17 @@ void main(List<String> args) {
       expect(
           exceptionUnknown.toString(), 'ExitException(999): Unknown exit code: 999');
     });
+
+    test('Check throwExit and ExitException accepts Object as message', () {
+      final customException = Exception('Test Exception');
+      expect(
+        () => wrongUsage.throwExit(customException),
+        throwsA(isA<ExitException>()
+            .having((e) => e.exitCode, 'exitCode', wrongUsage)
+            .having((e) => e.message, 'message', customException)
+            .having((e) => e.toString(), 'toString',
+                'ExitException(64): Exception: Test Exception')),
+      );
+    });
   });
 }


### PR DESCRIPTION
This PR enhances the utility of `ExitCodeExtension` by changing the `message` parameter type from `String?` to `Object?` in `exitProcess`, `throwExit`, and `ExitException`. This allows users to pass caught exceptions or other complex objects directly into the error-handling functions, preventing the need for repetitive `.toString()` boilerplate calls and improving overall developer UX when managing CLI exits.

### Changes
*   Updated `exitProcess` and `throwExit` in `ExitCodeExtension` to accept `[Object? message]`.
*   Updated `ExitException` to accept and store `Object? message`.
*   Used `message?.toString()` securely during exit output and exception formatting.
*   Added unit tests to `test/all_exit_codes_test.dart` to assert that objects like `Exception` are handled accurately.

### Why this is useful
In standard Dart CLI scripts, when an unexpected exception is caught, developers want to gracefully bubble it up or print it and exit. By supporting `Object?`, they can now succinctly write `catch (e) { wrongUsage.exitProcess(e); }` instead of manually formatting strings, simplifying usage significantly while keeping backward compatibility intact.

---
*PR created automatically by Jules for task [16767743279055878750](https://jules.google.com/task/16767743279055878750) started by @insign*