### PR TITLE
feat: change message parameter type to Object? to improve DX

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -171,7 +171,7 @@ extension ExitCodeExtension on int {
   /// If [message] is provided, it is printed to stdout if the exit code is
   /// [success], or to stderr if the exit code is an error.
   /// If [message] is not provided, the [exitDescription] is printed instead.
-  Never exitProcess([String? message]) {
+  Never exitProcess([Object? message]) {
     final msg = message ?? exitDescription;
     if (isError) {
       stderr.writeln(msg);
@@ -186,7 +186,7 @@ extension ExitCodeExtension on int {
   /// This is useful in CLI architectures to bubble up an exit status gracefully
   /// up the call stack instead of terminating the process immediately with
   /// [exitProcess], making unit testing much easier.
-  Never throwExit([String? message]) {
+  Never throwExit([Object? message]) {
     throw ExitException(this, message);
   }
 }
@@ -201,7 +201,7 @@ class ExitException implements Exception {
   final int exitCode;
 
   /// The custom message provided, if any.
-  final String? message;
+  final Object? message;
 
   /// Creates a new [ExitException].
   const ExitException(this.exitCode, [this.message]);

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -199,6 +199,21 @@ void main(List<String> args) {
       final exceptionUnknown = ExitException(999);
       expect(
           exceptionUnknown.toString(), 'ExitException(999): Unknown exit code: 999');
+
+      final exceptionWithObject = ExitException(dataError, Exception('Invalid data'));
+      expect(exceptionWithObject.toString(),
+          'ExitException(65): Exception: Invalid data');
+    });
+
+    test('Check throwExit extension works with Object (Exception)', () {
+      expect(
+        () => software.throwExit(Exception('System failure')),
+        throwsA(isA<ExitException>()
+            .having((e) => e.exitCode, 'exitCode', software)
+            .having((e) => e.message, 'message', isA<Exception>())
+            .having((e) => e.toString(), 'toString',
+                'ExitException(70): Exception: System failure')),
+      );
     });
   });
 }


### PR DESCRIPTION
Este PR altera os métodos `exitProcess`, `throwExit` e a classe `ExitException` para aceitar `Object?` ao invés de `String?` no parâmetro de mensagem. 
Isso é genuinamente útil porque as exceções capturadas em Dart (via blocos `catch (e)`) têm o tipo estático `Object` ou `dynamic`. Com essa mudança, o desenvolvedor não precisa mais chamar explicitamente `.toString()` ao lidar com exceções para usar as extensões. A compatibilidade é 100% garantida (já que `String` é um subtipo de `Object`), e a formatação com o interpolador de string nativo cuida automaticamente de converter o objeto fornecido. Foram adicionados e adaptados os testes para cobrir adequadamente esse novo cenário, comprovando seu funcionamento.

---
*PR created automatically by Jules for task [6775487897285113519](https://jules.google.com/task/6775487897285113519) started by @insign*