### PR TITLE
feat: add StackTrace support and graceful exit to ExitException

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -186,8 +186,8 @@ extension ExitCodeExtension on int {
   /// This is useful in CLI architectures to bubble up an exit status gracefully
   /// up the call stack instead of terminating the process immediately with
   /// [exitProcess], making unit testing much easier.
-  Never throwExit([Object? message]) {
-    throw ExitException(this, message);
+  Never throwExit([Object? message, StackTrace? stackTrace]) {
+    throw ExitException(this, message, stackTrace);
   }
 }
 
@@ -203,12 +203,21 @@ class ExitException implements Exception {
   /// The custom message provided, if any.
   final Object? message;
 
+  /// The stack trace associated with the exception, if any.
+  final StackTrace? stackTrace;
+
   /// Creates a new [ExitException].
-  const ExitException(this.exitCode, [this.message]);
+  const ExitException(this.exitCode, [this.message, this.stackTrace]);
+
+  /// Exits the process using this exception's [exitCode] and [message].
+  Never exitProcess() {
+    exitCode.exitProcess(message);
+  }
 
   @override
   String toString() {
     final msg = message ?? exitCode.exitDescription;
-    return 'ExitException($exitCode): $msg';
+    final traceStr = stackTrace != null ? '\n$stackTrace' : '';
+    return 'ExitException($exitCode): $msg$traceStr';
   }
 }

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -24,6 +24,18 @@ void main(List<String> args) {
   }
 }
 ''');
+
+      File('test/temp/test_exception_script.dart').writeAsStringSync('''
+import 'package:all_exit_codes/all_exit_codes.dart';
+
+void main() {
+  try {
+    wrongUsage.throwExit('Caught message');
+  } on ExitException catch (e) {
+    e.exitProcess();
+  }
+}
+''');
     });
 
     tearDownAll(() {
@@ -193,14 +205,15 @@ void main(List<String> args) {
           'ExitException(1): An error that occurred during the operation.');
 
       final exceptionWithMessage = ExitException(notADirectory, 'Custom error');
-      expect(exceptionWithMessage.toString(),
-          'ExitException(20): Custom error');
+      expect(
+          exceptionWithMessage.toString(), 'ExitException(20): Custom error');
 
       final exceptionUnknown = ExitException(999);
-      expect(
-          exceptionUnknown.toString(), 'ExitException(999): Unknown exit code: 999');
+      expect(exceptionUnknown.toString(),
+          'ExitException(999): Unknown exit code: 999');
 
-      final exceptionWithObject = ExitException(dataError, Exception('Invalid data'));
+      final exceptionWithObject =
+          ExitException(dataError, Exception('Invalid data'));
       expect(exceptionWithObject.toString(),
           'ExitException(65): Exception: Invalid data');
     });
@@ -214,6 +227,36 @@ void main(List<String> args) {
             .having((e) => e.toString(), 'toString',
                 'ExitException(70): Exception: System failure')),
       );
+    });
+
+    test('Check throwExit passes stackTrace correctly', () {
+      final trace = StackTrace.fromString('stack_trace_string');
+      expect(
+        () => generalError.throwExit('Message', trace),
+        throwsA(isA<ExitException>()
+            .having((e) => e.exitCode, 'exitCode', generalError)
+            .having((e) => e.message, 'message', 'Message')
+            .having((e) => e.stackTrace, 'stackTrace', trace)),
+      );
+    });
+
+    test('Check ExitException toString formatting with stackTrace', () {
+      final trace = StackTrace.fromString('stack_trace_string');
+      final exceptionWithTrace =
+          ExitException(dataError, 'Error message', trace);
+      expect(
+        exceptionWithTrace.toString(),
+        'ExitException(65): Error message\nstack_trace_string',
+      );
+    });
+
+    test('Check ExitException exitProcess correctly exits the process',
+        () async {
+      final result = await Process.run(
+          'dart', ['run', 'test/temp/test_exception_script.dart']);
+      expect(result.exitCode, wrongUsage);
+      expect(result.stdout.toString().trim(), isEmpty);
+      expect(result.stderr.toString().trim(), 'Caught message');
     });
   });
 }


### PR DESCRIPTION
Este PR adiciona suporte a `StackTrace` na classe `ExitException` e na extensão `throwExit`, além de um método `exitProcess()` diretamente na exceção. Isso é extremamente útil em aplicações CLI complexas, pois permite que desenvolvedores lancem erros em regras de negócios mantendo o contexto completo da trilha de execução (stack trace) para depuração mais eficaz, além de simplificar o encerramento gracioso do processo a partir de um bloco catch global (`catch (e) { e.exitProcess(); }`).

Foi respeitada a restrição de não incluir/comitar arquivos temporários, gerando-os dinamicamente durante os testes.

Passos realizados:
- Adicionadas propriedades e parâmetros de `StackTrace` em `lib/src/all_exit_codes_consts.dart`.
- Adicionado `ExitException.exitProcess()`.
- Criados novos scripts temporários dentro do `setUp` de testes para checagem em `test/all_exit_codes_test.dart`.
- Código validado via `dart format .`, `dart analyze` e `dart test`.

---
*PR created automatically by Jules for task [5829403938400563561](https://jules.google.com/task/5829403938400563561) started by @insign*