### PR TITLE
feat: add setExitCode method for graceful exit status handling

### DIFF
--- a/lib/src/all_exit_codes_consts.dart
+++ b/lib/src/all_exit_codes_consts.dart
@@ -181,6 +181,25 @@ extension ExitCodeExtension on int {
     exit(this);
   }
 
+  /// Sets the dart:io [exitCode] variable to this exit code and optionally logs a message.
+  ///
+  /// This is useful when you want to signal an exit status but allow the current
+  /// function to finish, or to allow graceful teardown and unflushed IO streams
+  /// to complete before the Dart VM naturally exits.
+  ///
+  /// If [message] is provided, it is printed to stdout if the exit code is
+  /// [success], or to stderr if the exit code is an error.
+  /// If [message] is not provided, the [exitDescription] is printed instead.
+  void setExitCode([Object? message]) {
+    final msg = message ?? exitDescription;
+    if (isError) {
+      stderr.writeln(msg);
+    } else {
+      stdout.writeln(msg);
+    }
+    exitCode = this;
+  }
+
   /// Throws an [ExitException] with this exit code.
   ///
   /// This is useful in CLI architectures to bubble up an exit status gracefully
@@ -222,5 +241,10 @@ class ExitException implements Exception {
   /// Exits the process with the [exitCode] and the given [message].
   Never exitProcess() {
     exitCode.exitProcess(message);
+  }
+
+  /// Sets the dart:io [exitCode] variable to the [exitCode] and the given [message].
+  void setExitCode() {
+    exitCode.setExitCode(message);
   }
 }

--- a/test/all_exit_codes_test.dart
+++ b/test/all_exit_codes_test.dart
@@ -13,15 +13,24 @@ void main() {
 import 'package:all_exit_codes/all_exit_codes.dart';
 
 void main(List<String> args) {
-  final isError = args[0] == 'error';
-  final hasMessage = args[1] == 'true';
+  final isException = args[0] == 'exception';
+  final isSetExitCode = args[0] == 'setExitCode';
+
+  final isError = isSetExitCode ? args[1] == 'error' : args[0] == 'error';
+  final hasMessage = isSetExitCode ? args[2] == 'true' : args[1] == 'true';
   final message = hasMessage ? 'Custom message' : null;
 
-  if (args[0] == 'exception') {
+  if (isException) {
     try {
       wrongUsage.throwExit(message, StackTrace.current);
     } on ExitException catch (e) {
       e.exitProcess();
+    }
+  } else if (isSetExitCode) {
+    if (isError) {
+      wrongUsage.setExitCode(message);
+    } else {
+      success.setExitCode(message);
     }
   } else if (isError) {
     wrongUsage.exitProcess(message);
@@ -219,6 +228,70 @@ void main(List<String> args) {
       expect(result.stdout.toString().trim(), isEmpty);
       expect(result.stderr.toString().trim(), 'Custom message');
     });
+
+    test('Check setExitCode extension with custom message on error', () async {
+      final result = await Process.run('dart', [
+        'run',
+        'test/temp/test_script.dart',
+        'setExitCode',
+        'error',
+        'true',
+      ]);
+      expect(result.exitCode, wrongUsage);
+      expect(result.stdout.toString().trim(), isEmpty);
+      expect(result.stderr.toString().trim(), 'Custom message');
+    });
+
+    test('Check setExitCode extension with default message on error', () async {
+      final result = await Process.run('dart', [
+        'run',
+        'test/temp/test_script.dart',
+        'setExitCode',
+        'error',
+        'false',
+      ]);
+      expect(result.exitCode, wrongUsage);
+      expect(result.stdout.toString().trim(), isEmpty);
+      expect(
+        result.stderr.toString().trim(),
+        'The command line usage is incorrect.',
+      );
+    });
+
+    test(
+      'Check setExitCode extension with custom message on success',
+      () async {
+        final result = await Process.run('dart', [
+          'run',
+          'test/temp/test_script.dart',
+          'setExitCode',
+          'success',
+          'true',
+        ]);
+        expect(result.exitCode, success);
+        expect(result.stderr.toString().trim(), isEmpty);
+        expect(result.stdout.toString().trim(), 'Custom message');
+      },
+    );
+
+    test(
+      'Check setExitCode extension with default message on success',
+      () async {
+        final result = await Process.run('dart', [
+          'run',
+          'test/temp/test_script.dart',
+          'setExitCode',
+          'success',
+          'false',
+        ]);
+        expect(result.exitCode, success);
+        expect(result.stderr.toString().trim(), isEmpty);
+        expect(
+          result.stdout.toString().trim(),
+          'The operation was successful.',
+        );
+      },
+    );
 
     test('Check throwExit extension throws ExitException', () {
       expect(


### PR DESCRIPTION
Esse PR adiciona o método `setExitCode([Object? message])` ao `ExitCodeExtension` e ao `ExitException`. Isso é realmente útil para aplicações CLI em Dart, pois permite sinalizar o código de saída no `dart:io` `exitCode` de forma não bloqueante, diferente do `exitProcess()` que encerra a VM abruptamente. Isso possibilita que blocos `finally` executem limpezas e garante que streams de IO (como `stdout` e `stderr`) sejam devidamente esvaziados (flushed) antes da aplicação terminar de forma graciosa.

- Adicionado `void setExitCode([Object? message])` na extension sobre `int` (`ExitCodeExtension`).
- Adicionado `void setExitCode()` na classe `ExitException`.
- Modificado o `test_script.dart` em tempo de execução para suportar asserção real de processo CLI com a nova funcionalidade.
- Cobertura de teste incluída com 100% de sucesso. Nenhuma quebra de testes pré-existentes.

---
*PR created automatically by Jules for task [9959305959370902110](https://jules.google.com/task/9959305959370902110) started by @insign*